### PR TITLE
avoid chaning viewports when using Ctrl+number

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -44,7 +44,7 @@ if (errorDiv) {
 
 let taskNum = '';
 document.addEventListener('keydown', function (event) {
-	if (event.keyCode >= 48 && event.keyCode <= 57) {
+	if (event.keyCode >= 48 && event.keyCode <= 57 && !event.ctrlKey) {
 		if (event.shiftKey && taskNum.length < 2) {
 			taskNum += String.fromCharCode(event.keyCode);
 		} else {
@@ -58,8 +58,10 @@ document.addEventListener('keydown', function (event) {
 });
 
 document.addEventListener('keyup', function (event) {
-	if (event.keyCode === 16) taskNum = '';
-	if (event.keyCode >= 48 && event.keyCode <= 57 && !event.shiftKey) taskNum = '';
+	if (!event.ctrlKey) {
+		if (event.keyCode === 16) taskNum = '';
+		if (event.keyCode >= 48 && event.keyCode <= 57 && !event.shiftKey) taskNum = '';
+	}
 });
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {


### PR DESCRIPTION
Usually, Chrome uses Ctrl+number to toggle between tabs. This would cause changing the viewport in the ALX project page when only trying to jump to another Chrome tab.

Example:
You're opening your ALX project and GitHub tabs in a Chrome window. You're currently on task 5's viewport. You want to check out your GitHub code, so you pressed Ctrl+2 to jump to GitHub tab. When you're back to the alx tab, you'll find yourself on task 2's viewport, which is not the desired behavior.

This pull request fixes the problem by preventing the intranet-extension's behavior of changing viewports when the ctrlKey is pressed.